### PR TITLE
Add inspection ficha regular schema and tests

### DIFF
--- a/__tests__/schemas/InspectionFichaRegular.schema.test.ts
+++ b/__tests__/schemas/InspectionFichaRegular.schema.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  inspectionFichaRegularSchema,
+  toInspectionFichaRegularPdfDTO,
+  InspectionFichaRegular,
+} from '../../schemas/InspectionFichaRegular.schema';
+
+const baseData: InspectionFichaRegular = {
+  dadosGerais: {
+    responsavel: 'João',
+    endereco: 'Rua A, 123',
+    data: '2024-01-01',
+  },
+  informacoesVistoria: {
+    presencaInsetosAnimais: false,
+    possuiPiscina: false,
+  },
+  estadoConservacao: {
+    condicaoEstrutural: 'boa',
+    necessitaReparo: false,
+  },
+  photos: [
+    {
+      uri: 'http://example.com/photo.jpg',
+      descricao: 'Frente do imóvel',
+    },
+  ],
+};
+
+describe('inspectionFichaRegularSchema', () => {
+  it('validates a correct payload', () => {
+    const parsed = inspectionFichaRegularSchema.parse(baseData);
+    expect(parsed.dadosGerais.responsavel).toBe('João');
+  });
+
+  it('requires observacaoInsetosAnimais when presencaInsetosAnimais is true', () => {
+    const data = {
+      ...baseData,
+      informacoesVistoria: {
+        ...baseData.informacoesVistoria,
+        presencaInsetosAnimais: true,
+      },
+    } as any;
+
+    expect(() => inspectionFichaRegularSchema.parse(data)).toThrow();
+  });
+
+  it('allows missing observacaoInsetosAnimais when presencaInsetosAnimais is false', () => {
+    const data = {
+      ...baseData,
+      informacoesVistoria: {
+        presencaInsetosAnimais: false,
+        possuiPiscina: false,
+      },
+    };
+
+    const parsed = inspectionFichaRegularSchema.parse(data);
+    expect(parsed.informacoesVistoria.observacaoInsetosAnimais).toBeUndefined();
+  });
+});
+
+describe('toInspectionFichaRegularPdfDTO', () => {
+  it('transforms parsed data into PDF DTO', () => {
+    const parsed = inspectionFichaRegularSchema.parse(baseData);
+    const dto = toInspectionFichaRegularPdfDTO(parsed);
+
+    expect(dto.sections[0].title).toBe('DADOS GERAIS');
+    expect(dto.photos.length).toBe(1);
+  });
+});
+

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -36,14 +37,16 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "zod": "^3.23.8"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
     "typescript": "~5.8.3",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~9.2.0"
+    "eslint-config-expo": "~9.2.0",
+    "vitest": "^1.6.0"
   },
   "private": true
 }

--- a/schemas/InspectionFichaRegular.schema.ts
+++ b/schemas/InspectionFichaRegular.schema.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod';
+
+/**
+ * Schema describing a regular inspection form. The structure mirrors the
+ * sections of the PDF that will be generated from the collected data.
+ */
+export const inspectionFichaRegularSchema = z.object({
+  /** DADOS GERAIS */
+  dadosGerais: z.object({
+    responsavel: z.string(),
+    endereco: z.string(),
+    data: z.string(),
+  }),
+
+  /** INFORMAÇÕES DA VISTORIA */
+  informacoesVistoria: z
+    .object({
+      presencaInsetosAnimais: z.boolean(),
+      observacaoInsetosAnimais: z.string().optional(),
+      possuiPiscina: z.boolean(),
+      observacaoPiscina: z.string().optional(),
+    })
+    .superRefine((data, ctx) => {
+      if (data.presencaInsetosAnimais && !data.observacaoInsetosAnimais) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['observacaoInsetosAnimais'],
+          message:
+            'observacaoInsetosAnimais is required when presencaInsetosAnimais is true',
+        });
+      }
+
+      if (data.possuiPiscina && !data.observacaoPiscina) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          path: ['observacaoPiscina'],
+          message: 'observacaoPiscina is required when possuiPiscina is true',
+        });
+      }
+    }),
+
+  /** ESTADO DE CONSERVAÇÃO */
+  estadoConservacao: z
+    .object({
+      condicaoEstrutural: z.enum(['boa', 'regular', 'ruim']),
+      necessitaReparo: z.boolean(),
+      observacaoReparo: z.string().optional(),
+    })
+    .refine(
+      (data) => !data.necessitaReparo || !!data.observacaoReparo,
+      {
+        message: 'observacaoReparo is required when necessitaReparo is true',
+        path: ['observacaoReparo'],
+      }
+    ),
+
+  /** PHOTOS */
+  photos: z
+    .array(
+      z.object({
+        uri: z.string(),
+        descricao: z.string().optional(),
+      })
+    )
+    .default([]),
+});
+
+/** Type inferred from {@link inspectionFichaRegularSchema}. */
+export type InspectionFichaRegular = z.infer<
+  typeof inspectionFichaRegularSchema
+>;
+
+/**
+ * DTO used for PDF generation. Each section contains a title and a map of
+ * string values. Photos are kept as an array and forwarded directly to the
+ * generator layer.
+ */
+export type InspectionFichaRegularPdfDTO = {
+  sections: Array<{ title: string; data: Record<string, string> }>;
+  photos: Array<{ uri: string; descricao?: string }>;
+};
+
+const boolToYesNo = (v: boolean) => (v ? 'Sim' : 'Não');
+
+/**
+ * Transforms parsed schema output into a structure friendly for PDF
+ * generation.
+ */
+export const toInspectionFichaRegularPdfDTO = (
+  data: InspectionFichaRegular
+): InspectionFichaRegularPdfDTO => ({
+  sections: [
+    {
+      title: 'DADOS GERAIS',
+      data: {
+        responsavel: data.dadosGerais.responsavel,
+        endereco: data.dadosGerais.endereco,
+        data: data.dadosGerais.data,
+      },
+    },
+    {
+      title: 'INFORMAÇÕES DA VISTORIA',
+      data: {
+        presencaInsetosAnimais: boolToYesNo(
+          data.informacoesVistoria.presencaInsetosAnimais
+        ),
+        observacaoInsetosAnimais:
+          data.informacoesVistoria.observacaoInsetosAnimais ?? '',
+        possuiPiscina: boolToYesNo(data.informacoesVistoria.possuiPiscina),
+        observacaoPiscina: data.informacoesVistoria.observacaoPiscina ?? '',
+      },
+    },
+    {
+      title: 'ESTADO DE CONSERVAÇÃO',
+      data: {
+        condicaoEstrutural: data.estadoConservacao.condicaoEstrutural,
+        necessitaReparo: boolToYesNo(
+          data.estadoConservacao.necessitaReparo
+        ),
+        observacaoReparo: data.estadoConservacao.observacaoReparo ?? '',
+      },
+    },
+  ],
+  photos: data.photos,
+});
+


### PR DESCRIPTION
## Summary
- add Zod schema for inspection ficha regular with conditional validations
- add utility to transform schema output into PDF DTO
- add unit tests for schema and PDF DTO

## Testing
- `npm test` (fails: sh: 1: vitest: not found)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a101939c488328b3f153ea6406a439