### PR TITLE
feat: add multi-step report wizard with autosave

### DIFF
--- a/features/reports/MultiStepReportForm.tsx
+++ b/features/reports/MultiStepReportForm.tsx
@@ -1,0 +1,61 @@
+import React, { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { reportSchema, ReportForm } from './schema';
+import OperationalSection from './components/OperationalSection';
+import ObservationSection from './components/ObservationSection';
+import { db } from './db';
+import { useAutosave } from './hooks/useAutosave';
+
+const steps = [
+  { id: 0, label: 'Operacional' },
+  { id: 1, label: 'Observações' },
+];
+
+export default function MultiStepReportForm() {
+  const form = useForm<ReportForm>({
+    resolver: zodResolver(reportSchema),
+    defaultValues: { hasBordaLivre: false, insetosAnimais: false },
+  });
+  const [step, setStep] = useState(0);
+
+  useEffect(() => {
+    const load = async () => {
+      const data = await db.reports.get(1);
+      if (data) {
+        form.reset(data);
+      }
+    };
+    void load();
+  }, [form]);
+
+  useAutosave(form, 1);
+
+  const next = () => setStep((s) => Math.min(s + 1, steps.length - 1));
+  const back = () => setStep((s) => Math.max(s - 1, 0));
+
+  const onSubmit = (data: ReportForm) => {
+    console.log('submit', data);
+  };
+
+  return (
+    <form onSubmit={form.handleSubmit(onSubmit)} aria-label="Report form" style={{ display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div aria-label="Progress">Step {step + 1} of {steps.length}</div>
+      {step === 0 && <OperationalSection form={form} />}
+      {step === 1 && <ObservationSection form={form} />}
+      <div style={{ display: 'flex', gap: 8 }}>
+        {step > 0 && (
+          <button type="button" onClick={back} aria-label="Previous step">
+            Back
+          </button>
+        )}
+        {step < steps.length - 1 && (
+          <button type="button" onClick={next} aria-label="Next step">
+            Next
+          </button>
+        )}
+        {step === steps.length - 1 && <button type="submit">Submit</button>}
+      </div>
+    </form>
+  );
+}

--- a/features/reports/__tests__/reportForm.test.tsx
+++ b/features/reports/__tests__/reportForm.test.tsx
@@ -1,0 +1,30 @@
+import 'fake-indexeddb/auto';
+import { describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { MultiStepReportForm } from '..';
+import { db } from '../db';
+
+describe('MultiStepReportForm', () => {
+  beforeEach(async () => {
+    await db.reports.clear();
+  });
+
+  it('shows conditional field when checkbox checked', async () => {
+    render(<MultiStepReportForm />);
+    expect(screen.queryByLabelText('Medida (m)')).toBeNull();
+    fireEvent.click(screen.getByLabelText('Has free board'));
+    expect(await screen.findByLabelText('Medida (m)')).toBeInTheDocument();
+  });
+
+  it('autosaves values to indexeddb', async () => {
+    render(<MultiStepReportForm />);
+    fireEvent.click(screen.getByLabelText('Has free board'));
+    const input = await screen.findByLabelText('Medida (m)');
+    fireEvent.change(input, { target: { value: '2' } });
+
+    await waitFor(async () => {
+      const rec = await db.reports.get(1);
+      expect(rec?.bordaLivreOperacionalMedidaM).toBe(2);
+    });
+  });
+});

--- a/features/reports/components/ObservationSection.tsx
+++ b/features/reports/components/ObservationSection.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { UseFormReturn } from 'react-hook-form';
+import { ReportForm } from '../schema';
+
+interface Props {
+  form: UseFormReturn<ReportForm>;
+}
+
+export default function ObservationSection({ form }: Props) {
+  const { register, watch, formState: { errors } } = form;
+  const hasInsetos = watch('insetosAnimais');
+
+  return (
+    <fieldset style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <legend>Observações</legend>
+      <label>
+        <input type="checkbox" {...register('insetosAnimais')} aria-label="Observou insetos ou animais" />
+        Insetos/Animais?
+      </label>
+      {hasInsetos && (
+        <div>
+          <label>
+            Observação
+            <textarea {...register('observacaoInsetosAnimais')} aria-required="true" />
+          </label>
+          {errors.observacaoInsetosAnimais && (
+            <span role="alert">{errors.observacaoInsetosAnimais.message}</span>
+          )}
+        </div>
+      )}
+    </fieldset>
+  );
+}

--- a/features/reports/components/OperationalSection.tsx
+++ b/features/reports/components/OperationalSection.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+import { UseFormReturn } from 'react-hook-form';
+import { ReportForm } from '../schema';
+
+interface Props {
+  form: UseFormReturn<ReportForm>;
+}
+
+export default function OperationalSection({ form }: Props) {
+  const { register, watch, formState: { errors } } = form;
+  const hasBorda = watch('hasBordaLivre');
+
+  return (
+    <fieldset style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+      <legend>Operacional</legend>
+      <label>
+        <input type="checkbox" {...register('hasBordaLivre')} aria-label="Has free board" />
+        Possui borda livre?
+      </label>
+      {hasBorda && (
+        <div>
+          <label>
+            Medida (m)
+            <input
+              type="number"
+              {...register('bordaLivreOperacionalMedidaM', { valueAsNumber: true })}
+              aria-required="true"
+            />
+          </label>
+          {errors.bordaLivreOperacionalMedidaM && (
+            <span role="alert">{errors.bordaLivreOperacionalMedidaM.message}</span>
+          )}
+        </div>
+      )}
+    </fieldset>
+  );
+}

--- a/features/reports/db.ts
+++ b/features/reports/db.ts
@@ -1,0 +1,18 @@
+import Dexie, { Table } from 'dexie';
+import type { ReportForm } from './schema';
+
+export interface ReportRecord extends ReportForm {
+  id?: number;
+}
+
+class ReportsDB extends Dexie {
+  reports!: Table<ReportRecord, number>;
+  constructor() {
+    super('ReportsDB');
+    this.version(1).stores({
+      reports: '++id'
+    });
+  }
+}
+
+export const db = new ReportsDB();

--- a/features/reports/hooks/useAutosave.ts
+++ b/features/reports/hooks/useAutosave.ts
@@ -1,0 +1,15 @@
+import { useEffect } from 'react';
+import { UseFormReturn, useWatch } from 'react-hook-form';
+import { db } from '../db';
+import { ReportForm } from '../schema';
+
+export function useAutosave(form: UseFormReturn<ReportForm>, id: number = 1) {
+  const values = useWatch({ control: form.control });
+
+  useEffect(() => {
+    const save = async () => {
+      await db.reports.put({ id, ...values });
+    };
+    void save();
+  }, [values, id]);
+}

--- a/features/reports/index.ts
+++ b/features/reports/index.ts
@@ -1,0 +1,2 @@
+export { default as MultiStepReportForm } from './MultiStepReportForm';
+export * from './schema';

--- a/features/reports/schema.ts
+++ b/features/reports/schema.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+export const reportSchema = z.object({
+  hasBordaLivre: z.boolean().default(false),
+  bordaLivreOperacionalMedidaM: z
+    .number({ invalid_type_error: 'Obrigatório' })
+    .optional()
+    .refine((val, ctx) => {
+      if (ctx.parent.hasBordaLivre) {
+        return typeof val === 'number';
+      }
+      return true;
+    }, { message: 'Obrigatório' }),
+  insetosAnimais: z.boolean().default(false),
+  observacaoInsetosAnimais: z
+    .string()
+    .optional()
+    .refine((val, ctx) => {
+      if (ctx.parent.insetosAnimais) {
+        return !!val;
+      }
+      return true;
+    }, { message: 'Obrigatório' }),
+});
+
+export type ReportForm = z.infer<typeof reportSchema>;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "vitest run"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -36,14 +37,23 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "react-hook-form": "^7.52.1",
+    "@hookform/resolvers": "^3.9.0",
+    "zod": "^3.23.8",
+    "dexie": "^4.0.6"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
     "typescript": "~5.8.3",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~9.2.0"
+    "eslint-config-expo": "~9.2.0",
+    "vitest": "^1.6.0",
+    "@testing-library/react": "^16.0.0",
+    "@testing-library/jest-dom": "^6.5.0",
+    "jsdom": "^24.0.0",
+    "fake-indexeddb": "^5.0.2"
   },
   "private": true
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+  },
+});


### PR DESCRIPTION
## Summary
- build report form components with conditional logic tied to Zod schema
- add multi-step wizard with progress and IndexedDB autosave hooks
- cover conditional fields and autosave with component tests

## Testing
- `npm run lint`
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a10194a0b88328895e1ca9e39baaba