### PR TITLE
Add risk score utility with summary and tests

### DIFF
--- a/features/reports/__tests__/riskScore.test.ts
+++ b/features/reports/__tests__/riskScore.test.ts
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  calculateRiskScore,
+  buildSummaryBlock,
+  RiskOption,
+} from '../riskScore';
+import { generatePdf, generatePreview } from '../pdf';
+
+test('calculates total for single option', () => {
+  const result = calculateRiskScore(['medium']);
+  assert.equal(result.total, 2);
+  assert.deepEqual(result.breakdown, [{ option: 'medium', value: 2 }]);
+});
+
+test('calculates total for multiple options', () => {
+  const result = calculateRiskScore(['low', 'high', 'medium']);
+  assert.equal(result.total, 6); // 1 + 3 + 2
+});
+
+test('builds summary block with aggregate score', () => {
+  const summary = buildSummaryBlock(['high', 'high']);
+  assert.equal(summary, 'Aggregate risk score: 6');
+});
+
+test('handles empty selections with zero score', () => {
+  const result = calculateRiskScore([] as RiskOption[]);
+  assert.equal(result.total, 0);
+  assert.deepEqual(result.breakdown, []);
+});
+
+test('generatePdf includes summary block', () => {
+  const pdf = generatePdf(['low', 'medium']);
+  assert.ok(pdf.includes('Aggregate risk score: 3'));
+});
+
+test('generatePreview mirrors PDF summary', () => {
+  const preview = generatePreview(['high']);
+  assert.equal(preview, 'Aggregate risk score: 3');
+});

--- a/features/reports/pdf.ts
+++ b/features/reports/pdf.ts
@@ -1,0 +1,20 @@
+import { RiskOption, buildSummaryBlock } from './riskScore';
+
+/**
+ * Generates a simple string-based PDF representation including the summary
+ * block with the aggregate risk score. In the real application this would
+ * interface with a PDF library.
+ */
+export function generatePdf(selections: RiskOption[]): string {
+  const summary = buildSummaryBlock(selections);
+  // In a real implementation the summary would be added to the PDF document.
+  return `PDF Report\n${summary}`;
+}
+
+/**
+ * Creates a preview representation containing the same summary block that
+ * will appear in the final PDF.
+ */
+export function generatePreview(selections: RiskOption[]): string {
+  return buildSummaryBlock(selections);
+}

--- a/features/reports/riskScore.ts
+++ b/features/reports/riskScore.ts
@@ -1,0 +1,39 @@
+export type RiskOption = 'low' | 'medium' | 'high';
+
+// Numeric values associated with each risk option
+export const RISK_OPTION_VALUES: Record<RiskOption, number> = {
+  low: 1,
+  medium: 2,
+  high: 3,
+};
+
+export interface ScoreBreakdown {
+  option: RiskOption;
+  value: number;
+}
+
+export interface ScoreResult {
+  total: number;
+  breakdown: ScoreBreakdown[];
+}
+
+/**
+ * Maps a list of selected risk options to their numeric values and returns
+ * the aggregate score.
+ */
+export function calculateRiskScore(selections: RiskOption[]): ScoreResult {
+  const breakdown = selections.map((option) => ({
+    option,
+    value: RISK_OPTION_VALUES[option] ?? 0,
+  }));
+  const total = breakdown.reduce((sum, item) => sum + item.value, 0);
+  return { total, breakdown };
+}
+
+/**
+ * Builds a summary block to be displayed in both preview and PDF output.
+ */
+export function buildSummaryBlock(selections: RiskOption[]): string {
+  const { total } = calculateRiskScore(selections);
+  return `Aggregate risk score: ${total}`;
+}


### PR DESCRIPTION
## Summary
- add risk score utility to map options to numeric values
- include PDF/preview helpers that show aggregate score in a summary block
- test score calculation for various option combinations

## Testing
- `npx tsc features/reports/riskScore.ts features/reports/pdf.ts features/reports/__tests__/riskScore.test.ts --outDir build --module commonjs --target ES2020 --esModuleInterop`
- `node --test build/__tests__/riskScore.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a10197f5588328aac7cd0e35d19865