### PR TITLE
feat: add reports dashboard

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,5 +1,9 @@
 import { Stack } from "expo-router";
 
 export default function RootLayout() {
-  return <Stack />;
+  return (
+    <Stack>
+      <Stack.Screen name="index" options={{ title: "Dashboard" }} />
+    </Stack>
+  );
 }

--- a/app/index.tsx
+++ b/app/index.tsx
@@ -1,15 +1,5 @@
-import { Text, View } from "react-native";
+import Dashboard from "../features/reports/Dashboard";
 
 export default function Index() {
-  return (
-    <View
-      style={{
-        flex: 1,
-        justifyContent: "center",
-        alignItems: "center",
-      }}
-    >
-      <Text>Edit app/index.tsx to edit this screen.</Text>
-    </View>
-  );
+  return <Dashboard />;
 }

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,0 +1,6 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+  };
+};

--- a/features/reports/Dashboard.test.tsx
+++ b/features/reports/Dashboard.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import Dashboard from './Dashboard';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
+);
+
+const seedData = [
+  { id: '1', title: 'Draft report', status: 'draft' },
+  { id: '2', title: 'Completed report', status: 'completed' },
+];
+
+describe('Dashboard', () => {
+  beforeEach(async () => {
+    await AsyncStorage.setItem('reports', JSON.stringify(seedData));
+  });
+
+  it('lists draft and completed reports', async () => {
+    const { findByText } = render(<Dashboard />);
+    expect(await findByText('Draft report')).toBeTruthy();
+    expect(await findByText('Completed report')).toBeTruthy();
+  });
+
+  it('creates a report offline', async () => {
+    const { getByTestId, findByText } = render(<Dashboard />);
+    fireEvent.press(getByTestId('create-report'));
+    await findByText('Report 3');
+    const stored = await AsyncStorage.getItem('reports');
+    const reports = JSON.parse(stored || '[]');
+    expect(reports).toHaveLength(3);
+  });
+});

--- a/features/reports/Dashboard.tsx
+++ b/features/reports/Dashboard.tsx
@@ -1,0 +1,97 @@
+import React, { useEffect, useState } from 'react';
+import { View, Text, Button, FlatList } from 'react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export type Report = {
+  id: string;
+  title: string;
+  status: 'draft' | 'completed';
+};
+
+const STORAGE_KEY = 'reports';
+
+export default function Dashboard() {
+  const [reports, setReports] = useState<Report[]>([]);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const json = await AsyncStorage.getItem(STORAGE_KEY);
+        if (json) {
+          setReports(JSON.parse(json));
+        }
+      } catch (e) {
+        console.warn('Failed to load reports', e);
+      }
+    };
+    load();
+  }, []);
+
+  const persist = async (next: Report[]) => {
+    setReports(next);
+    try {
+      await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+    } catch (e) {
+      console.warn('Failed to save reports', e);
+    }
+  };
+
+  const createReport = async () => {
+    const newReport: Report = {
+      id: Date.now().toString(),
+      title: `Report ${reports.length + 1}`,
+      status: 'draft',
+    };
+    await persist([...reports, newReport]);
+  };
+
+  const setStatus = async (id: string, status: Report['status']) => {
+    const next = reports.map((r) => (r.id === id ? { ...r, status } : r));
+    await persist(next);
+  };
+
+  const drafts = reports.filter((r) => r.status === 'draft');
+  const completed = reports.filter((r) => r.status === 'completed');
+
+  const resumeReport = (id: string) => console.log('resume', id);
+  const previewReport = (id: string) => console.log('preview', id);
+  const exportReport = (id: string) => console.log('export', id);
+  const syncReport = (id: string) => console.log('sync', id);
+
+  return (
+    <View style={{ flex: 1, padding: 16 }}>
+      <Button title="Create Report" onPress={createReport} testID="create-report" />
+      <Text accessibilityRole="header">Draft Reports</Text>
+      <FlatList
+        testID="draft-list"
+        data={drafts}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={{ marginVertical: 8 }}>
+            <Text>{item.title}</Text>
+            <Button title="Resume" onPress={() => resumeReport(item.id)} />
+            <Button
+              title="Complete"
+              onPress={() => setStatus(item.id, 'completed')}
+              testID={`complete-${item.id}`}
+            />
+          </View>
+        )}
+      />
+      <Text accessibilityRole="header">Completed Reports</Text>
+      <FlatList
+        testID="completed-list"
+        data={completed}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <View style={{ marginVertical: 8 }}>
+            <Text>{item.title}</Text>
+            <Button title="Preview" onPress={() => previewReport(item.id)} />
+            <Button title="Export" onPress={() => exportReport(item.id)} />
+            <Button title="Sync" onPress={() => syncReport(item.id)} />
+          </View>
+        )}
+      />
+    </View>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "test": "jest"
   },
   "dependencies": {
     "@expo/vector-icons": "^14.1.0",
@@ -36,14 +37,24 @@
     "react-native-safe-area-context": "5.4.0",
     "react-native-screens": "~4.11.1",
     "react-native-web": "~0.20.0",
-    "react-native-webview": "13.13.5"
+    "react-native-webview": "13.13.5",
+    "@react-native-async-storage/async-storage": "^1.23.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
     "@types/react": "~19.0.10",
     "typescript": "~5.8.3",
     "eslint": "^9.25.0",
-    "eslint-config-expo": "~9.2.0"
+    "eslint-config-expo": "~9.2.0",
+    "@testing-library/react-native": "^12.5.2",
+    "@testing-library/jest-native": "^5.7.0",
+    "jest": "^29.7.0",
+    "jest-expo": "~53.0.2",
+    "react-test-renderer": "19.0.0"
+  },
+  "jest": {
+    "preset": "jest-expo",
+    "setupFilesAfterEnv": ["@testing-library/jest-native/extend-expect"]
   },
   "private": true
 }


### PR DESCRIPTION
## Summary
- add report dashboard with draft and completed lists and offline storage
- wire dashboard into root layout and index route
- add component tests and jest setup

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a1019b28bc8328ae5401a71bf13c01